### PR TITLE
Add workaround for Forge runners.

### DIFF
--- a/.github/workflows/compute-starter-kit-rust-v2.yml
+++ b/.github/workflows/compute-starter-kit-rust-v2.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Uninstall existing Rust toolchain (workaround for some runner images)
+        run: rustup toolchain uninstall stable
+
       - name: Setup Rust toolchain with caching
         uses: actions-rust-lang/setup-rust-toolchain@v1
 


### PR DESCRIPTION
When this workflow is used on a Forge runner, installing any version of Rust that is different from the version present in the runner image fails. The workaround is to uninstall the existing toolchain first.

Tested in https://github.com/fastly/http-me/actions/runs/24671811294/job/72144442187?pr=52.