### PR TITLE
Strip the leading `v` from expected version before comparison

### DIFF
--- a/.github/workflows/publish-rust-crates-io-v1.yml
+++ b/.github/workflows/publish-rust-crates-io-v1.yml
@@ -38,6 +38,8 @@ jobs:
         if: inputs.expected_version != '' && inputs.crate_name != ''
         run: |
           EXPECTED_VERSION="${{ inputs.expected_version }}"
+          # Strip leading 'v' if present (e.g., v1.0.0 -> 1.0.0)
+          EXPECTED_VERSION="${EXPECTED_VERSION#v}"
           CRATE_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "${{ inputs.crate_name }}") | .version')
           if [ "$EXPECTED_VERSION" != "$CRATE_VERSION" ]; then
             echo "::error::Expected version ($EXPECTED_VERSION) does not match crate version ($CRATE_VERSION)"

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ version before publishing.
 * `expected_version` - (optional) Expected crate version. If provided, must match the `version`
   field in the crate's `Cargo.toml` file, or the workflow fails. Requires `crate_name` to also
   be specified; the workflow will fail if `expected_version` is set without `crate_name`.
+  A leading `v` prefix (e.g., `v1.0.0`) is automatically stripped before comparison.
 
 #### Outputs
 


### PR DESCRIPTION
The README gives an example of passing in an `expected_version` that looks like `v0.1.0`, but the actual comparison logic is expecting a version without the leading `v`.

This pull request updates the version checker to strip the leading `v`, if present, before comparing to the version reported by `cargo metadata`.